### PR TITLE
Add rant about California partition strategy

### DIFF
--- a/doc/california-partition.rst
+++ b/doc/california-partition.rst
@@ -1,0 +1,357 @@
+The California Partition: A Strategy for Implementation
+========================================================
+
+Executive Summary
+-----------------
+
+California can partition itself into four independent states without first obtaining congressional approval. The conventional analysis—that Article IV, Section 3 of the Constitution requires congressional consent before any partition—confuses the question of what Congress must ratify with the question of what Congress can prevent. By executing a comprehensive delegation of state powers to regional governments, California can create a de facto partition where the only remaining federal question is Senate representation. At that point, Congress faces not a request for permission but a fait accompli, and the political costs of non-recognition fall entirely on the holdouts.
+
+This paper outlines the mechanism, the political dynamics, and the implementation pathway for partitioning California into four states: Jefferson, the Bay Area, Central Valley, and Southern California.
+
+Part I: The Mechanism
+----------------------
+
+The Core Insight
+~~~~~~~~~~~~~~~~
+
+The standard approach to state partition treats congressional consent as a gating requirement—something that must be obtained before any action can be taken. This framing is both legally formalist and strategically disempowering. It places California in a supplicant position, asking permission from a body with no particular incentive to grant it.
+
+The alternative approach is legal realist: What can California do unilaterally, and what can Congress actually prevent?
+
+California can, through voter proposition (which cannot be overturned by the legislature), authorize:
+
+- Creation of four regional governments with defined boundaries
+- Delegation of all state legislative authority to regional legislatures
+- Delegation of all executive authority to regional governors
+- Restructuring of state agencies into regional agencies
+- Drawing of congressional districts entirely within regional boundaries
+- Direction of all state administrative systems to operate on a regional basis
+
+What remains for Congress is a single question: whether to seat six additional senators (two from each new state) and formally recognize the partition. This is the only thing California cannot do unilaterally.
+
+Why This Works
+~~~~~~~~~~~~~~
+
+The federal government has no mechanism to force California to operate as a unified state. Consider the enforcement question for each element:
+
+**Legislative delegation**: California's legislature has broad authority to delegate powers to subordinate entities. Counties and cities already exercise delegated authority. There is no federal requirement that California maintain a unitary legislative structure.
+
+**Executive delegation**: The governor can reorganize executive functions and delegate authority to regional executives. This is administrative reorganization, not a federal question.
+
+**Agency restructuring**: The California Highway Patrol becomes four regional law enforcement agencies. The DMV becomes four regional DMVs. These are state agencies being reorganized by the state. No federal permission is required.
+
+**Congressional districts**: California controls its own redistricting. Drawing all Bay Area districts within the Bay Area, all Jefferson districts within Jefferson, etc., is entirely within state authority.
+
+**Administrative systems**: When the California DMV tells the TSA "for REAL ID verification, you now need to query these four regional databases," the TSA will comply. Their mission is identity verification, not federalism enforcement.
+
+The federal government could, in theory, refuse to recognize the partition for purposes of federal funding formulas. But this creates pressure toward recognition, not against the de facto arrangement—California's regions would loudly complain about being underserved relative to their population, generating political pressure on Congress.
+
+The Proposition Structure
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The partition must be enacted by voter proposition, not legislative action. This is critical for two reasons:
+
+1. **Irreversibility**: Under California law, the legislature cannot overturn a proposition. This means there is no one for the federal government to pressure into reversing course. The governor can shrug and say, "I'd love to help resolve this chaos, but I can't overturn a proposition. Recognize the regions and the chaos ends."
+
+2. **Democratic legitimacy**: The partition isn't politicians seeking power—it's the people of California exercising democratic self-determination. This makes federal non-recognition look like Congress overriding the democratic will of 40 million people.
+
+The proposition should include:
+
+- Defined boundaries for the four regions
+- Framework for delegation of legislative and executive authority
+- Transition timeline (effective date approximately 18-24 months post-passage)
+- Water rights provisions (see Part III)
+- Direction to negotiate interstate reciprocity agreements
+- Authorization for regional constitutional conventions
+
+Part II: The Political Dynamics
+--------------------------------
+
+Why Every Region Votes Yes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The partition proposition passes because every region has self-interested reasons to support it, and no region sees itself as benefiting from the current arrangement.
+
+**Jefferson**: This region has maintained an active secessionist movement since 1941. They have a flag, a seal (the "Double Cross," representing being double-crossed by Sacramento and Salem), and have held symbolic elections for state officials. They are not going to need convincing. For Jefferson, the proposition is the culmination of an 80-year political project.
+
+**Bay Area**: The region is the financial engine of California but lacks policy autonomy. Housing policy, transportation investment, and tech regulation all run through Sacramento, where legislators from Central Valley and Jefferson have votes. An independent Bay Area can pursue aggressive YIMBY housing policy, prioritize transit investment, and experiment with technocratic governance according to its own values. The "subsidy" framing is irrelevant—the Bay Area would rather have autonomy than money.
+
+**Central Valley**: This region has long resented environmental regulations that constrain agricultural water use, imposed by urban legislators who don't depend on farming. The transfer payments from wealthier regions feel like patronizing compensation for regulatory interference. Central Valley's preference is straightforward: "Keep your money, give us back control of our water."
+
+**Southern California**: LA and San Diego are not supplicants. The region has Hollywood, major ports, aerospace, and massive real estate wealth. They don't want Bay Area "weirdos" telling them how to run their business. And crucially, SoCal can buy its way out of water dependence through desalination—something that's been blocked partly by state-level environmental permitting. An independent SoCal with streamlined regulations could have abundant water within a decade.
+
+The "No" Coalition
+~~~~~~~~~~~~~~~~~~
+
+Who opposes the proposition?
+
+- Sacramento politicians who lose power
+- A small number of Californians sentimentally attached to the state as a unified concept
+- Perhaps some labor unions concerned about fragmentation (though their members remain employed)
+
+This is not a coalition that wins proposition fights. There is no regional constituency for "no," no self-interested bloc that benefits from the status quo. The proposition passes with support from all four regions, probably by a substantial margin.
+
+Congressional Recognition: The Embarrassment Strategy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once the proposition passes and the de facto partition takes effect, Congress faces a choice: recognize the partition (seating six new senators) or refuse recognition (leaving the new states represented by California's existing two senators).
+
+The conventional analysis treats this as a partisan math problem that Democrats cannot solve because Republicans will block additional Democratic senators. This analysis fails for several reasons.
+
+**The Partisan Math Is Unclear**
+
+Currently, California is +2 Democratic senators, permanently. No Republican investment in California Senate races makes sense.
+
+After the partition:
+
+- Jefferson: +2 Republican (rural, conservative, the whole point of their secessionist movement)
+- Bay Area: +2 Democratic (locked)
+- Southern California: +2 Democratic (probably locked)
+- Central Valley: Competitive
+
+If Central Valley goes Republican, the partition produces a net -2 Democratic change from the status quo (from +2 D to 0). If Central Valley goes Democratic, the partition produces a net +2 Democratic change (from +2 D to +4 D).
+
+So a Republican senator blocking recognition might be:
+
+- Preventing a +2 Democratic gain, OR
+- Preventing a +2 Republican gain
+
+Even if Central Valley initially elects Democrats, it's a genuinely competitive state where Republican investment could pay off—rural, agricultural, culturally conservative. Republicans go from "zero California senators forever" to "guaranteed +2 from Jefferson, plus a real battleground in Central Valley."
+
+**The Embarrassment Campaign**
+
+The key to flipping the handful of Republican votes needed is not dealmaking but embarrassment.
+
+Imagine the visual: Jefferson holds an election for "would-be senators." The state has a Republican governor. California's two sitting Democratic senators represent, in part, Jefferson—a conservative rural region that voted for partition precisely because they don't want Democratic representation.
+
+Now stage a nationally broadcast town hall with five people:
+
+- Two Democratic senators saying, "We should not be representing Jefferson"
+- Two Republican would-be senators saying, "We should be representing Jefferson"
+- A Republican governor saying, "My constituents are being denied representation"
+
+The only villain in this story is Congress. There is no partisan attack available. You cannot call it a Democratic power grab when Republicans from Jefferson are the most visibly aggrieved party.
+
+**The Attack Ad**
+
+Every Republican senator who votes against recognition has handed their Democratic opponent in a swing state a weapon:
+
+"Senator Smith voted to deny representation to the people of Jefferson State. Jefferson is a rural, conservative state—and Senator Smith voted to keep them from having senators who share their values. If he won't stand up for Republicans in California, will he really stand up for Republicans here?"
+
+This ad works in Georgia, Arizona, Nevada—any state with a competitive Senate race. The bipartisan victim framing makes it impossible to spin as a team sport. The tribal defense doesn't activate because the visible victims are rural conservative Republicans.
+
+**The Ratchet**
+
+Every month that passes without recognition makes the situation worse for holdouts:
+
+- More interstate reciprocity agreements get signed
+- More federal programs route through the regions
+- More official documents list "Bay Area" as the state
+- More absurdist situations accumulate (see Part III on jury selection)
+
+There is no stable equilibrium where Congress refuses forever. The pressure ratchets in one direction only.
+
+**The Flip Math**
+
+The Senate vote requires a simple majority (or 60 votes if filibustered, but see below). All Democratic senators will vote yes—they're adding at least 4 Democratic senators and possibly 6. So the question is how many Republicans need to flip.
+
+The answer is: not many. And the pitch isn't ideological—it's pure electoral self-interest. "You're taking definite damage now, creating attack ad material, and you might be preventing two Republican senators from taking office. Vote yes, take credit for Jefferson, and make the problem go away."
+
+As for the filibuster: try filibustering the democratic self-determination of 40 million Americans while rural Republicans beg you on camera to let them have representation. That's not a filibuster that holds.
+
+Part III: Implementation Details
+---------------------------------
+
+Water Rights
+~~~~~~~~~~~~
+
+The single most common objection to California partition is water. Southern California and the Bay Area depend on water from Central Valley and the Sierra Nevada. Won't partition lead to water wars?
+
+The proposition resolves this cleanly:
+
+**Transition period**: For 10 years post-partition, water rights and allocations remain at status quo. Existing contracts, existing infrastructure, existing flows. No immediate disruption.
+
+**End state**: After 10 years, each state owns the water within its boundaries. Federal water projects (Colorado River) remain subject to federal/interstate allocation, as they already are.
+
+This structure works because:
+
+1. **SoCal and Bay Area can engineer around dependence**. Desalination is expensive but feasible. An independent SoCal with streamlined environmental permitting could build abundant desalination capacity within a decade. The current system persists partly because it's cheaper than alternatives and because California's regulations make desalination difficult. Independence changes both factors.
+
+2. **Central Valley has no incentive to restrict water during transition**. They're still getting paid for it, and any hostile action just accelerates SoCal's investment in desalination. Better to sell water profitably for a decade than to start a fight that makes your customer independent faster.
+
+3. **The end state is a Schelling point**. "Water that's in your borders is yours" requires no ongoing negotiation or complex interstate compacts. It's simple, intuitive, and final.
+
+Law Enforcement
+~~~~~~~~~~~~~~~
+
+California Highway Patrol becomes four regional agencies. This is simpler than it sounds:
+
+- CHP officers currently stationed in Jefferson become Jefferson Highway Patrol
+- CHP officers in the Bay Area become Bay Area Highway Patrol (or merge with an expanded BART Police, which already has multi-county jurisdiction and the institutional DNA for regional operation)
+- Similarly for Central Valley and Southern California
+
+No officer loses their job. The same people drive the same cars on the same routes. The change is organizational—who they report to, what patch they wear.
+
+BART Police is instructive. It already operates across nine counties, already has its own command structure, already ignores city/county boundaries. Expanding its jurisdiction and hiring the "fired" CHP officers is relabeling, not institution-building.
+
+DMV and Identity Documents
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+California currently issues driver's licenses and state IDs through a single DMV. Post-partition:
+
+- Four regional DMVs issue regional licenses/IDs
+- California DMV notifies TSA: "For REAL ID verification, query these four databases"
+- TSA complies (their mission is security, not constitutional interpretation)
+- Regional IDs work at airports immediately
+
+For interstate driving:
+
+- Each new state negotiates reciprocity agreements with all 49 existing states
+- In practice, every state will sign, because the alternative is their residents can't drive in California's successor states either
+- The network effects favor rapid universal adoption
+
+Driver's licenses become the template for other state-issued credentials: professional licenses, vehicle registrations, etc. In each case, the existing California system is split into four regional systems, and interstate reciprocity agreements handle cross-recognition.
+
+Federal Courts
+~~~~~~~~~~~~~~
+
+The partition creates interesting complications for federal court jurisdiction in California. Currently, there are four federal district courts covering different parts of the state. Post-partition:
+
+The embarrassment strategy extends to federal courts. Imagine a jury trial where a juror from Sacramento says, "I cannot fairly judge a case from Jefferson—we're from different states with different values." This isn't jury nullification; it's a legitimate venue objection under the de facto arrangement.
+
+Enough such complications, and federal courts in "California" become increasingly dysfunctional. The resolution is obvious: recognize the partition and realign federal court jurisdiction to match reality.
+
+Federal Funding
+~~~~~~~~~~~~~~~
+
+Federal funding flows to "states" as Congress defines them. Federal funds continue flowing to "California," which passes them through to the regional governments according to a pre-determined formula specified in the proposition. This is simply how it works—California receives federal funding and distributes it to its subordinate governmental entities, exactly as it already does with counties and various state programs.
+
+The formula is locked in by the proposition, so no region can be punished or favored by Sacramento politics. The federal government has no leverage here: they send money to California, California sends it to the regions. There's no bottleneck to pressure and no decision-maker to influence.
+
+Members of Congress
+~~~~~~~~~~~~~~~~~~~
+
+Post-partition, California's congressional representatives continue serving. But:
+
+- Their districts were drawn within regional boundaries, so each represents a single region
+- They can (and should) identify themselves on the House floor as "the Representative from the great state of the Bay Area" or "from Jefferson"
+- This is symbolic but contributes to the normalization of the partition and the embarrassment of non-recognition
+
+Interstate Relations
+~~~~~~~~~~~~~~~~~~~~
+
+Prior to the partition taking effect, California should negotiate:
+
+- Driver's license reciprocity with all 50 states
+- Professional license reciprocity (or state-by-state as needed)
+- Tax coordination agreements with the IRS
+- Interstate compact memberships (transferred to relevant successor state)
+
+The key insight is that other states have no reason to refuse these agreements. Texas gains nothing from refusing to recognize Bay Area driver's licenses—it just means Texans can't drive in the Bay Area. The network effects push strongly toward universal recognition of the de facto situation.
+
+Part IV: Campaign Strategy
+---------------------------
+
+Phase 1: Salience
+~~~~~~~~~~~~~~~~~
+
+The first objective is making the partition mechanism salient among California's political class. The idea must transition from "interesting thought experiment" to "serious political proposal" in elite discourse.
+
+Tactics:
+
+- Op-eds in California political publications (CalMatters, LA Times, SF Chronicle)
+- Policy papers from think tanks (ideally one left-leaning, one right-leaning, one libertarian)
+- Academic symposium on the constitutional questions
+- Social media engagement from politically active accounts in all four regions
+- Outreach to California legislators willing to discuss publicly
+
+The goal is not immediate conversion but legitimization. Once serious people are discussing the mechanism seriously, the formalist objections dissolve under scrutiny.
+
+Phase 2: Coalition Building
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Build support across all four regions by emphasizing region-specific benefits:
+
+**Jefferson outreach**: Contact existing State of Jefferson movement organizations. They've been working on this for 80 years—they're the natural core of the campaign in that region. Message: "We're going to actually do it this time, and here's how."
+
+**Central Valley outreach**: Agricultural associations, water districts, rural county supervisors. Message: "Sacramento will never stop telling you how to run your farms. Independence is the only path to agricultural autonomy."
+
+**Bay Area outreach**: Tech industry leaders, YIMBY organizations, transit advocates, housing policy reformers. Message: "Every policy you've wanted for decades—housing, transit, tech governance—becomes possible with independence."
+
+**Southern California outreach**: Business leaders, port authorities, entertainment industry, San Diego interests (often neglected in LA-centric California politics). Message: "You're a major global economy being governed by people who don't understand your needs. Time to govern yourselves."
+
+Phase 3: Proposition Campaign
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Standard California proposition campaign tactics, but with a few key elements:
+
+**Bipartisan leadership**: The campaign should have visible leaders from all four regions and both parties. A Jefferson Republican and a Bay Area Democrat as co-chairs, for example. This immunizes against the "partisan power grab" attack.
+
+**Regional autonomy framing**: The central message isn't "split California" but "let each region govern itself." Positive framing about self-determination, not negative framing about divorce.
+
+**Address water directly**: Don't let opponents make water the issue. The 10-year transition with clean end state should be explained clearly and repeatedly.
+
+**Anticipate and rebut the congressional objection**: "Congress will never approve this." Response: "Congress doesn't have to approve it. The only question is whether they'll embarrass themselves by denying representation to four new states."
+
+Phase 4: Post-Passage Implementation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once the proposition passes:
+
+**Immediate**: Begin setting up regional governmental structures, negotiating interstate agreements, and preparing for administrative transition.
+
+**Ongoing**: Coordinate the embarrassment campaign for congressional recognition. Regional officials, would-be senators, and California's existing senators should maintain consistent public pressure.
+
+**Long-term**: Once recognition passes, complete the transition to fully independent states.
+
+Part V: Objections and Responses
+---------------------------------
+
+"Congress will never approve this"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Congress doesn't need to approve the de facto partition—only the seating of new senators. And the political cost of non-recognition is high and increases over time. A handful of Republican senators can be flipped by a combination of partisan math (they might be blocking Republican senators from Jefferson and Central Valley) and electoral self-interest (avoiding attack ads about denying representation to rural conservatives).
+
+"This is unconstitutional"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It isn't. California has broad authority to reorganize its internal governance. Delegation of powers to regional entities is well within state authority. The only federal question is Senate representation, which is admittedly beyond California's unilateral power—hence the recognition campaign.
+
+"The federal government will intervene"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+How? What agency, under what authority, would force California to un-delegate powers to its regions? There is no federal requirement that California maintain a unitary state government. The enforcement mechanism doesn't exist.
+
+"This will cause chaos"
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The 18-24 month transition period and detailed implementation planning minimize disruption. The same people do the same jobs with different reporting structures. Water rights are preserved for a decade. Interstate agreements ensure continuity of driver's licenses and other credentials. The chaos argument is a reason for careful planning, not for inaction.
+
+"Water wars will result"
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The 10-year transition period prevents immediate conflict. SoCal and Bay Area can build desalination capacity during this period. Central Valley has no incentive to restrict water while they're being paid for it. The end state—each state owns water in its borders—is a simple Schelling point requiring no ongoing negotiation.
+
+"California's economy benefits from integration"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Each region would remain in the United States, with full freedom of movement, commerce, and trade with other regions. The economic integration that matters is federal (interstate commerce, free movement, common currency), and that persists unchanged. What ends is political integration—being governed by Sacramento—which is exactly what every region wants.
+
+"I'm sentimentally attached to California as a unified state"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+That's a legitimate preference, but it's not a majority position in any region. When every region wants autonomy, the sentimental preference of a minority should not override democratic self-determination.
+
+Conclusion
+----------
+
+California partition is achievable through a mechanism that bypasses the conventional requirement for prior congressional consent. By implementing the partition through voter proposition and comprehensive delegation of state powers, California can create a de facto four-state reality where Congress's only remaining role is recognition—recognition that becomes politically untenable to withhold.
+
+The strategy requires:
+
+1. Making the mechanism salient in political discourse
+2. Building a cross-regional coalition focused on regional autonomy
+3. Passing a well-designed proposition
+4. Executing a disciplined post-passage campaign to secure congressional recognition
+
+The pieces are all available. What's been missing is the strategic frame that shows how they fit together. Once that frame becomes salient, California's political class will recognize what has always been true: the four regions don't want to be together, and they don't have to be.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -33,3 +33,4 @@ Moshe'z Rants
     jewish-thanksgiving
     foundation_thesis
     northwestern-semitic-paradox
+    california-partition


### PR DESCRIPTION
Adds comprehensive analysis of how California could partition into four states
(Jefferson, Bay Area, Central Valley, Southern California) through voter proposition
and delegation of state powers, bypassing traditional congressional consent requirements.