### PR TITLE
Add essay on the Late Bronze Age collapse

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -34,3 +34,4 @@ Moshe'z Rants
     foundation_thesis
     northwestern-semitic-paradox
     california-partition
+    lba-collapse

--- a/doc/lba-collapse.rst
+++ b/doc/lba-collapse.rst
@@ -1,0 +1,77 @@
+The LBA Collapse is not a Mystery
+==================================
+
+The Late Bronze Age collapse is routinely described as one of history's great mysteries. Between roughly 1200 and 1150 BCE, the interconnected palace economies of the Eastern Mediterranean—Mycenaean Greece, the Hittite Empire, Ugarit, the Egyptian New Kingdom's Levantine holdings—fell apart in rapid succession. Cities burned. Trade networks severed. Writing systems vanished for centuries in some regions. Scholars have proposed drought, earthquakes, the enigmatic Sea Peoples, systems complexity, volcanic eruptions, and disease. No consensus has emerged. The collapse remains, we are told, unexplained.
+
+But the answer is in the name. We call it the transition from the Bronze Age to the Iron Age. Perhaps we should take that nomenclature seriously.
+
+The Standard Objection
+----------------------
+
+The obvious response is that early iron was inferior to bronze for weapons. This is true. Iron working in 1200 BCE could not produce steel; the resulting blades were softer, held an edge poorly, and broke more easily than good bronze. A warrior equipped with a bronze sword and shield had a material advantage over one with iron equivalents. If iron weapons were worse, how could iron have caused the collapse of bronze-age civilization?
+
+This objection misunderstands the argument. The question is not which metal wins in a duel. The question is which metal breaks the oligopoly on organized violence.
+
+The Economics of Bronze
+-----------------------
+
+Bronze is an alloy of copper and tin. Copper is relatively abundant across the Mediterranean and Near East. Tin is not. The major tin sources for the Bronze Age world were Afghanistan, Cornwall, and perhaps the Erzgebirge region of central Europe—all distant from the centers of Bronze Age civilization.
+
+This created a particular political economy. To equip an army with bronze weapons, you needed access to long-distance trade networks. To maintain those networks, you needed diplomatic relationships with other palace economies, or the military power to secure trade routes. The tin trade was the strategic resource of its era, analogous to oil in the twentieth century.
+
+The palace economies that dominated the Late Bronze Age were built around this constraint. The Mycenaean palaces, the Hittite administration, the Egyptian New Kingdom, the Levantine city-states—all of them derived power partly from their ability to control access to bronze. If you could not get tin, you could not arm a serious military force. The only entities that could field effective armies were states large enough to participate in the tin trade.
+
+This meant that the only military threats a Bronze Age empire faced came from other Bronze Age empires or from their own internal elite. Peasant uprisings, pastoral nomads, hill peoples, bandits—none of these could scale their violence effectively. They could be nuisances, but they could not field the kind of force that threatened imperial power. The logistics and security systems of these empires were optimized for this threat environment.
+
+Iron Changes the Calculation
+----------------------------
+
+Iron ore is everywhere. It is one of the most abundant metals in the Earth's crust. Unlike tin, it does not require long-distance trade networks to acquire. Any community with access to bog iron, surface deposits, or basic mining could potentially produce iron implements.
+
+The implications were not primarily military in the conventional sense. An iron sword was not going to defeat a bronze sword in single combat. An iron-equipped army was not going to defeat a bronze-equipped army of equal size and training in pitched battle. The empires were not overthrown by superior military technology.
+
+The implications were economic and logistical. For the first time, it was possible to arm significant numbers of men without participating in the palace economy's trade networks. Groups that had been effectively locked out of military significance—because they could not access tin—could now equip themselves with weapons that were, if not superior, at least adequate.
+
+Adequate for what? Not for conquering empires. For raiding.
+
+The Guerrilla Hypothesis
+------------------------
+
+Consider the situation from the perspective of a Bronze Age empire. Your army is built around chariot forces and professional infantry equipped with expensive bronze weapons. Your logistics depend on secure trade routes connecting agricultural centers to administrative hubs. Your threat model assumes that the only serious enemies are other empires or large organized forces.
+
+Now suppose that groups previously beneath military notice can suddenly arm themselves with cheap iron weapons. They cannot defeat your army in battle. But they do not need to. They can raid supply convoys. They can ambush small garrisons. They can make the roads unsafe. They can interrupt the flow of agricultural surplus from countryside to palace, the flow of tin from distant sources to bronze foundries, the flow of tribute from periphery to center.
+
+Your empire is not designed to counter this threat. You cannot station enough troops everywhere to secure every road. Deploying your chariot forces against dispersed raiders is ineffective—they simply melt away and reappear elsewhere. The cost of securing your supply lines against endemic raiding begins to exceed the value of what flows through them.
+
+This is not conquest. It is erosion.
+
+The Evidence
+------------
+
+What does the textual evidence from the Late Bronze Age collapse actually describe? The Amarna letters, the Ugarit correspondence, the Egyptian records—these do not primarily describe great invasions or decisive battles. They describe something that sounds remarkably like endemic insecurity: complaints about groups variously termed 'apiru, Shasu, or simply "raiders" making roads unsafe, disrupting agriculture, threatening outlying settlements.
+
+The Sea Peoples, so often invoked as the mysterious cause of the collapse, fit this pattern as well. They were not a unified invasion force with a homeland and a political agenda. They were a heterogeneous collection of groups, some arriving by sea, engaging in raiding and opportunistic settlement. The Egyptian records describe defeating them in battle—and yet the collapse continued. Defeating raiders in battle does not solve the problem of raiding, any more than winning a battle against guerrillas ends an insurgency.
+
+The Sea Peoples were not the cause of the collapse. They were a symptom of it—one of many groups taking advantage of the new strategic environment that cheap iron had created.
+
+The Collapse Mechanism
+----------------------
+
+The palace economies of the Bronze Age were tightly coupled systems. They depended on long-distance trade for strategic materials, on agricultural surplus extracted from the countryside, on specialized craft production concentrated in palace complexes, on administrative systems that coordinated all of these flows. This integration was their strength in stable conditions. It became their vulnerability when the security environment changed.
+
+Once raiding became endemic and supply lines became unreliable, the system began to fail in cascading fashion. Without secure tin supplies, bronze production faltered. Without bronze, the professional military forces that secured trade routes could not be maintained. Without secure trade routes, the palace economies could not function. Without functioning palace economies, the administrative systems that organized agriculture and craft production collapsed. Without those systems, populations dispersed, cities were abandoned, and the knowledge embedded in palatial institutions—including, in some cases, writing itself—was lost.
+
+Egypt survived, weakened, because the Nile provided internal lines of communication that did not depend on overland trade routes. Assyria survived because it had transitioned earlier to iron and had a military system less dependent on chariot warfare. The Phoenician cities survived because their maritime position allowed them to maintain trade networks that overland raiding could not interdict. The pattern of survival supports the hypothesis: those polities that were less vulnerable to disruption of overland logistics weathered the collapse.
+
+The Answer in the Name
+----------------------
+
+The Late Bronze Age collapse is not a mystery requiring exotic explanations. It is the predictable consequence of a technological transition that undermined the economic basis for centralized military power.
+
+Bronze required imperial scale. Iron democratized violence.
+
+The empires did not fall because iron was better than bronze. They fell because iron was *available* without their permission. The monopoly on serious military force that had sustained the palace economies for centuries was broken not by a superior army but by the impossibility of maintaining security against distributed, low-level, persistent threats that had never before existed at scale.
+
+We call it the Bronze Age collapse because that is what it was: the collapse of a political-economic system built on the characteristics of bronze. We call what followed the Iron Age because iron's characteristics—abundant, locally sourceable, adequate—defined the new strategic environment.
+
+The mystery was never really a mystery. The answer was in the name all along.


### PR DESCRIPTION
Argues that the LBA collapse is explained by iron's democratization of violence - iron ore's ubiquity allowed peripheral groups to arm themselves and conduct endemic raiding that eroded palace economies dependent on long-distance tin trade networks.