### PR TITLE
Add essay on True Blood and antisemitic tropes

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -35,3 +35,4 @@ Moshe'z Rants
     northwestern-semitic-paradox
     california-partition
     lba-collapse
+    true-blood

--- a/doc/true-blood.rst
+++ b/doc/true-blood.rst
@@ -1,0 +1,95 @@
+True Blood Is Antisemitic, and It's OK to Watch It
+===================================================
+
+The Tropes Are Specific
+-----------------------
+
+True Blood's vampire society is built on a very specific set of tropes: a minority that can "pass" among the majority, whose members are indistinguishable on sight. Ancient and wealthy, with shadowy governing councils. Dual-coded as both parasitic and secretly powerful. Internal loyalty suspected of superseding loyalty to broader society. Literally predatory relationships with blood. Internal debates about assimilation versus maintaining separate identity. Ancient religious texts and fundamentalist factions. Internal courts that handle crimes within the community rather than submitting to the surrounding society's legal system.
+
+This constellation doesn't map well onto the experiences the show gestures toward. The "God Hates Fangs" signs evoke homophobia, and the show seems to think it's doing an LGBT rights allegory. But homophobia and anti-Black racism operate on visible difference and disgust, not hidden infiltration and secret power. The paranoid structure True Blood uses—the hidden enemy who looks like us, the secret elite, the ancient conspiracy—that's not how those prejudices typically work.
+
+The specific cluster of tropes—passing, internal courts, respectable advocacy organizations as fronts, assimilation as strategic deception, secret governing councils, the vindication of paranoid fears—isn't "vampires." It's a choice about what metaphorical architecture to build vampire society on.
+
+The AVL Is One Letter Away
+---------------------------
+
+The American Vampire League does PR and lobbying for mainstreaming. It fights defamation of vampires in media. It presents a respectable public face while a more radical hidden power structure operates behind the scenes. Nan Flanagan, its spokesperson, uses rhetoric that sounds less like GLAAD or BLM and more like the defensive crouch of mid-20th century Jewish advocacy: "we're just like you, we contribute to society, accusations against us are bigoted slander."
+
+And then the show reveals that the AVL is a front for something sinister. Nan is eventually killed by the vampires she was protecting—a narrative about what happens to the assimilationist collaborator when she's no longer useful to the real power structure.
+
+It's hard to write "AVL" in a writers' room and not notice it's one letter off from "ADL." The cast and crew would have said the acronym out loud repeatedly.
+
+Salome
+------
+
+The Authority, the secret vampire governing council at the center of Season 5, is a show invention—it's not from the books. The show chose to add: a centralized global conspiracy, a religious fundamentalist infiltration plot, the vindication of paranoid fears about what's really going on, and a literal Jewish woman as the hidden mastermind.
+
+Salome is a real historical figure—a Herodian princess attested in Josephus who married Philip the Tetrarch and then Aristobulus of Chalcis. But the show isn't using Salome-the-historical-figure. It's using Salome-the-figure-from-the-Gospels: the seductive dancer who demanded John the Baptist's head on a platter. That story isn't historically attested outside Christian scripture. Josephus mentions John's execution but gives political reasons and no dance.
+
+The Gospel Salome is a Christian literary construction—the seductive Jewish princess who uses her sexuality to manipulate weak men and kill God's prophet. Medieval Christian artists transformed her into the personification of the lascivious woman, a temptress who lures men away from salvation. The "Dance of the Seven Veils" and the whole Wilde/Strauss decadent-exotic-Oriental image grew from this.
+
+True Blood imports all of that. The show gives her the surname "Agrippa" to emphasize her Herodian/Jewish identity. She's a secretly scheming religious fundamentalist who manipulates everyone, uses seduction as her primary tool, and works to undermine the "civilized" (mainstreaming) vampires from within. She's the hidden enemy inside the institution.
+
+She's the only character on the show whose identity is literally, textually Jewish. And she's the secret manipulator at the heart of the conspiracy.
+
+At some point, someone in the writers' room said "the mastermind of the conspiracy should be Salome" and everyone agreed. That's not unconsciously reproducing tropes. That's casting the role.
+
+The Great Revelation Is Non-Load-Bearing
+-----------------------------------------
+
+Here's the thing: you can remove the entire premise of vampires being publicly known, and nothing in the plot breaks.
+
+Season 1 is a serial killer investigation in a small town. Season 2 is Maryann the maenad, a hidden supernatural threat. Season 3 is Russell Edgington and werewolves. Season 4 is witches and amnesiac Eric. The actual stories are monster-of-the-year plots that would work in any vampire setting with a masquerade.
+
+Sookie's telepathy not working on vampires? Works with hidden vampires. Human-vampire romances with the tension of a dangerous partner? That's Buffy or Anne Rice. Vampire factions and internal politics? Standard. A charismatic vampire terrorist who other vampires want to stop because he's drawing dangerous attention? That's every vampire story with a Masquerade.
+
+Rene murdering women who slept with vampires works—his sister got involved with one, and now he kills women who follow the same path. The Fellowship of the Sun works—they become a group that knows a secret truth that mainstream society denies, like UFO believers. Steve Newlin becomes more unsettling this way: a guy who knows something true that sounds insane, humiliated and radicalized by not being believed.
+
+Even the Authority works. The Sanguinistas vs. mainstreaming faction maps directly onto "break the masquerade" vs. "maintain the masquerade." That's a standard vampire fiction conflict—the Volturi exist precisely to enforce secrecy. You just don't call the villain Salome. Any ancient scheming femme fatale works in that role.
+
+The world already has shifters, weres, fairies, witches—all operating under a masquerade. The show knows how to tell stories about hidden supernatural beings. Harris specifically chose to make vampires the exception and give them the public existence, the civil rights movement, the assimilation debate, the respectable organizations, the internal courts, the question of dual loyalty.
+
+The masquerade isn't one option among many—it's the genre default. Every vampire property uses it: Blade, Buffy, Anne Rice, Twilight, Underworld, The Vampire Diaries. Harris had to actively reject the convention. Of all the ways to deviate from it, she chose this specific set of tropes, from this specific source.
+
+What the Tropes Add
+--------------------
+
+The Great Revelation adds exactly one thing: the assimilation narrative. The "are they really safe to live among us" question. The respectable advocacy organization. The internal debate between vampires who want to integrate and vampires who think humans are cattle. The revelation that assimilation was never sincere.
+
+And crucially: the show keeps validating the paranoia. The vampires actually are dangerous. Mainstreaming actually is a cover for darker agendas. The Authority actually is run by secret fundamentalists who want to enslave humanity. The nice public-facing assimilationist rhetoric actually is concealing something sinister.
+
+It's not "prejudice is wrong." It's "the prejudiced people are basically correct to be afraid, and the civil rights rhetoric is a front."
+
+The show lets itself have it both ways—it feels progressive by showing bigots with "God Hates Fangs" signs, while its actual plot structure confirms every fever dream about hidden minorities with secret power who can't really be trusted to live among normal people.
+
+Packaging
+---------
+
+True Blood is an example of packaged antisemitism—tropes wrapped in deniability. Anyone who points it out can be dismissed as reading too much into a fun HBO show about sexy vampires. "It's just entertainment." "It's actually about gay rights, didn't you see the signs?"
+
+This is how most antisemitism circulates now. Not manifestos, but story shapes. Not explicit claims, but narrative logic that makes certain suspicions feel satisfying when confirmed. Not "Jews are dangerous" but "isn't it interesting how the assimilation turned out to be a trick."
+
+The packaging finds its audience. Anti-Zionism gives the left "we're just criticizing a state's policies." Supersessionism gives the right "the Old Covenant was fulfilled." Secular academic language gives the educated middle "two traditions emerged from common roots" (framing Christianity as an equally legitimate heir and erasing Jewish continuity). Vampire fiction gives genre fans this.
+
+300 works the same way. It gives you physically perfected Aryan-coded Spartans standing for "freedom" against a monstrous, racially-mixed Persian horde. The Spartans—who ran a brutal slave society—become freedom fighters. The Persians—who practiced relative religious tolerance—become tyranny incarnate. The film inverts Jewish historical memory completely: Cyrus is called messiah in Isaiah, the liberator who ended the Babylonian exile and funded the Temple's rebuilding. In Jewish memory, Persia is the redemption. 300 demonizes the liberators using explicit Aryan visual coding, and it doesn't have to mention Jews at all. The audience's pattern-matching does the work.
+
+The AVL serves a similar function. The show trains you to watch a respectable advocacy organization operate, hear its rhetoric, see its spokespeople. Then it reveals everything was a front. The next time you see the actual ADL doing actual advocacy, some part of your brain has been primed with "but what's really going on behind the scenes." Not because the show told you to think that, but because it gave you a story where that suspicion was validated.
+
+There's a meta-irony here: the show includes a one-letter-off parody of the organization that identifies antisemitic packaging, portrays it as a front for something sinister, and is itself an example of the kind of packaged antisemitism that organization has to keep pointing at.
+
+It's OK to Watch It
+-------------------
+
+The quality question and the content question are separate.
+
+True Blood is well-written. The dialogue is sharp, the pacing works, the characters are compelling, the Southern Gothic atmosphere is effective. The actors have chemistry. The scene-level craft is genuinely good. None of that has anything to do with the Great Revelation. Eric's deadpan delivery, Pam's comments, Lafayette's entire presence, Jessica's arc—these exist independently of the assimilation premise.
+
+You could have the exact same quality of scene work with a masquerade premise instead. The antisemitic architecture is purely additive. It was built on top of a functional vampire story and bought nothing in return.
+
+But it's there. And acknowledging it matters.
+
+The move that needs resisting is "I enjoyed it, therefore it can't be problematic" or "it's problematic, therefore no one should enjoy it." Both are evasions. The uncomfortable position is holding both: this is well-crafted entertainment that does real ideological work, and you consumed it, and maybe it did some of that work on you, and you still enjoyed it.
+
+That's all you can really do. Not purity, but clarity. Notice when the reveal feels satisfying and ask why. Recognize when a story has trained you to find certain suspicions intuitive. See clearly what you're watching.
+
+True Blood is antisemitic. It's also entertaining. Both things, at the same time. The honest response isn't to pretend either one away.


### PR DESCRIPTION
This essay analyzes how True Blood's vampire metaphor uses specific antisemitic tropes including:
- Passing minorities with secret power structures
- The AVL as a one-letter-off ADL parody portrayed as a front
- Salome as the Jewish mastermind of the conspiracy
- Validation of paranoid fears about assimilation as deception

The essay argues this is "packaged antisemitism" wrapped in deniability, while acknowledging the show can still be enjoyed as entertainment.